### PR TITLE
Output (null) when string argument is nullptr

### DIFF
--- a/v3kprintf.h
+++ b/v3kprintf.h
@@ -597,7 +597,8 @@ static inline int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen
       }
 
       case 's' : {
-        char *p = va.next<Ptr<char>>(cpu, mem).get(mem);
+        const char *p = va.next<Ptr<char>>(cpu, mem).get(mem);
+        p = p != nullptr ? p : "(null)";
         unsigned int l = _strlen(p);
         // pre padding
         if (flags & FLAGS_PRECISION) {


### PR DESCRIPTION
This fixes the crash when running A Boy and His Blob Vita3K/compatibility#866 caused by a null pointer being passed for a string argument to sceClibVsnprintf in libsceavplayer so it will go ingame.

If accepted I will then make a pull request to the main repo to update to the updated submodule.